### PR TITLE
Adds support for nested geometries

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,23 +4,33 @@
     <meta charset="utf-8">
     <title>Glow Component - A-Frame</title>
     <meta name="description" content="Glow Component - A-Frame">
+    <!-- a-frame lib -->
     <script src="https://aframe.io/releases/0.6.1/aframe.min.js"></script>
+    <!-- glow component -->
     <script src="lib/glow.js"></script>
+    <!-- 3d model of a chair (io3d-furniture component) -->
+    <script src="http://localhost:8080/build/3dio.js"></script>
   </head>
   <body>
     <a-scene>
+      <a-sky src="static/background.jpg"></a-sky>
 
+      <!-- native components -->
+      <a-box glow="enabled:true" position="-1 0.5 -3" rotation="0 45 0" color="#4CC3D9"></a-box>
+      <a-sphere glow="enabled:true; scale:1.3" position="0 1.25 -5" radius="1.25" color="#EF2D5E"></a-sphere>
+      <a-cylinder glow="side: front; scale:1.3; c: 1; p: 1.3; color: #FF00FF;" position="1 0.75 -3" radius="0.5" height="1.5" color="#FFC65D"></a-cylinder>
+      <a-plane position="0 0 -4" rotation="-90 0 0" width="4" height="4" color="#7BC8A4"></a-plane>
+
+      <!-- OBJ model -->
       <a-assets>
         <a-asset-item id="tree-obj" src="https://rawgit.com/mrdoob/three.js/dev/examples/obj/cubes/cubes.obj"></a-asset-item>
         <a-asset-item id="tree-mtl" src="https://rawgit.com/mrdoob/three.js/dev/examples/obj/cubes/cubes.mtl"></a-asset-item>
       </a-assets>
       <a-entity glow="enabled:true; scale:1.5" obj-model="obj: #tree-obj; mtl: #tree-mtl" position="-30 0 -40" opacity="0.9"></a-entity>
 
-      <a-box glow="enabled:true" position="-1 0.5 -3" rotation="0 45 0" color="#4CC3D9"></a-box>
-      <a-sphere glow="enabled:true; scale:1.3" position="0 1.25 -5" radius="1.25" color="#EF2D5E"></a-sphere>
-      <a-cylinder glow="side: front; scale:1.3; c: 1; p: 1.3; color: #FF00FF;" position="1 0.75 -3" radius="0.5" height="1.5" color="#FFC65D"></a-cylinder>
-      <a-plane position="0 0 -4" rotation="-90 0 0" width="4" height="4" color="#7BC8A4"></a-plane>
-      <a-sky src="static/background.jpg"></a-sky>
+      <!-- model of chair -->
+      <a-entity glow="enabled:true; scale:1.1" io3d-furniture="id:943357e8-911f-4bb5-8b89-8281385ef08f" position="4 0 -4"></a-entity>
+
     </a-scene>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
         <a-asset-item id="tree-obj" src="https://rawgit.com/mrdoob/three.js/dev/examples/obj/cubes/cubes.obj"></a-asset-item>
         <a-asset-item id="tree-mtl" src="https://rawgit.com/mrdoob/three.js/dev/examples/obj/cubes/cubes.mtl"></a-asset-item>
       </a-assets>
-      <a-entity glow="enabled:true; scale:3.3" obj-model="obj: #tree-obj; mtl: #tree-mtl" position="-30 0 -40" opacity="0.9"></a-entity>
+      <a-entity glow="enabled:true; scale:1.5" obj-model="obj: #tree-obj; mtl: #tree-mtl" position="-30 0 -40" opacity="0.9"></a-entity>
 
       <a-box glow="enabled:true" position="-1 0.5 -3" rotation="0 45 0" color="#4CC3D9"></a-box>
       <a-sphere glow="enabled:true; scale:1.3" position="0 1.25 -5" radius="1.25" color="#EF2D5E"></a-sphere>

--- a/lib/glow.js
+++ b/lib/glow.js
@@ -34,14 +34,27 @@ AFRAME.registerComponent('glow', {
     		transparent: true
     	});
 
-      // ISSUE for OBJs: >> line below
-      var object = that.el.object3DMap.mesh.geometry.clone();
-      object = new THREE.Geometry().fromBufferGeometry(object);
-      var modifier = new THREE.BufferSubdivisionModifier( 2 );
-      object = modifier.modify( object );
-
-      that.glowMesh = new THREE.Mesh( object, that.glowMaterial);
-    	scene.add( that.glowMesh );
+			// create geometry
+			var glowGeometry = new THREE.Geometry()
+			var sourcMesh = that.el.object3DMap.mesh
+			if (sourcMesh.type === 'Mesh') {
+				// single geometry
+				glowGeometry.fromBufferGeometry(sourcMesh.geometry);
+			} else {
+				// merge nested geometries
+				sourcMesh.clone().traverse(function (child) {
+					if (child.parent) {
+						child.updateMatrixWorld();
+						child.applyMatrix(child.parent.matrixWorld);
+					}
+					if (child.geometry) glowGeometry.merge(new THREE.Geometry().fromBufferGeometry(child.geometry));
+				});
+			}
+			// round up geometry with subdivision modifier
+			glowGeometry = new THREE.BufferSubdivisionModifier(2).modify(glowGeometry);
+			// wrap it up & add to scene
+			that.glowMesh = new THREE.Mesh(glowGeometry, that.glowMaterial);
+			scene.add(that.glowMesh);
 
       if (!that.data.enabled) {
        that.glowMesh.visible = false;

--- a/lib/glow.js
+++ b/lib/glow.js
@@ -36,13 +36,13 @@ AFRAME.registerComponent('glow', {
 
 			// create geometry
 			var glowGeometry = new THREE.Geometry()
-			var sourcMesh = that.el.object3DMap.mesh
-			if (sourcMesh.type === 'Mesh') {
+			var sourceMesh = that.el.object3DMap.mesh
+			if (sourceMesh.type === 'Mesh') {
 				// single geometry
-				glowGeometry.fromBufferGeometry(sourcMesh.geometry);
+				glowGeometry.fromBufferGeometry(sourceMesh.geometry);
 			} else {
 				// merge nested geometries
-				sourcMesh.clone().traverse(function (child) {
+				sourceMesh.clone().traverse(function (child) {
 					if (child.parent) {
 						child.updateMatrixWorld();
 						child.applyMatrix(child.parent.matrixWorld);


### PR DESCRIPTION
a first step creating glow for nested geometries by merging them into one (flattening its hierarchy).

brings up another challenge: visual result isn't what the user would expect since because merging nested geometries does flatten the center points into one and applying scale later results in weird looking offsets:
![glow_component_-_a-frame](https://user-images.githubusercontent.com/6619499/29921633-a7559d5a-8e52-11e7-85d3-aa503ea6f8e9.jpg)

i know that @stavros-papadopoulos has been working on some very nice and performant solutions for this. maybe  he could help out once he's back from vacation? ;)