### PR TITLE
Fix world position bug

### DIFF
--- a/src/glow.js
+++ b/src/glow.js
@@ -25,7 +25,7 @@ AFRAME.registerComponent('glow', {
     			"c":   { type: "f", value: that.data.c },
     			"p":   { type: "f", value: that.data.p },
     			glowColor: { type: "c", value: new THREE.Color(that.data.color) },
-    			viewVector: { type: "v3", value: camera.position }
+                viewVector: { type: "v3", value: new THREE.Vector3().subVectors(camera.position, that.el.getAttribute('position')) }
     		},
     		vertexShader:   THREE.__GlowShader.vertexShader,
     		fragmentShader: THREE.__GlowShader.fragmentShader,
@@ -87,8 +87,13 @@ AFRAME.registerComponent('glow', {
       this.glowMesh.rotation.set(this.el.object3D.rotation.x, this.el.object3D.rotation.y, this.el.object3D.rotation.z);
       this.glowMesh.scale.set(this.el.object3D.scale.x*this.data.scale, this.el.object3D.scale.y*this.data.scale, this.el.object3D.scale.z*this.data.scale);
       if (!this.camera) { return; }
+      // getWorldPosition doesn't work in VR mode, according to this: https://github.com/aframevr/aframe/issues/4568#issuecomment-622992096
+      // so we need to calculate world position a little differently
+      var glowMeshWorldPosition = new THREE.Vector3();
+      this.el.object3D.updateMatrixWorld();
+      glowMeshWorldPosition.setFromMatrixPosition(this.el.object3D.matrixWorld);
       this.glowMesh.material.uniforms.viewVector.value =
-    		new THREE.Vector3().subVectors( this.camera.position, this.glowMesh.position );
+        new THREE.Vector3().subVectors( this.camera.position, glowMeshWorldPosition );
     }
   },
   remove: function () {


### PR DESCRIPTION
The glowing mesh only looks correct from one angle, and in theory that angle should be facing the camera at all times. This used to be calculated with local coordinates instead of global coordinates, which resulted in incorrect meshes. This changes coordinates so the glowing mesh looks correct.

Screenshots, with c = 0.2 and p = 1.4:

Before:

![image](https://user-images.githubusercontent.com/13173037/102696536-29474500-41fd-11eb-9d5d-42f8b8ea7bc5.png)

After:

![image](https://user-images.githubusercontent.com/13173037/102696501-dec5c880-41fc-11eb-9e8f-b06b980dd6f5.png)
